### PR TITLE
clarify special in-memory URL for sqlite

### DIFF
--- a/guides/databases.md
+++ b/guides/databases.md
@@ -69,7 +69,7 @@ The afore-mentioned packages use `cds-plugin` techniques to automatically config
 {"cds":{
   "requires": {
     "db": {
-      "[development]": { "kind": "sqlite", "impl": "@cap-js/sqlite", "credentials": { "url": "memory" } },
+      "[development]": { "kind": "sqlite", "impl": "@cap-js/sqlite", "credentials": { "url": ":memory:" } },
       "[production]": { "kind": "hana", "impl": "@cap-js/hana", "deploy-format": "hdbtable" }
     }
   }


### PR DESCRIPTION
Attempting to add some explicit configuration for an in-memory sqlite database I encountered this inconsistency. In other places in the docs `:memory:` is used. `memory` did not work for me as it supposedly expects a plain file named `memory`. Hence suggesting this change.