### PR TITLE
IntelliJ IDEA Community support

### DIFF
--- a/java/getting-started.md
+++ b/java/getting-started.md
@@ -193,7 +193,7 @@ CAP Java projects can be edited best in a Java IDE. Leaving CDS support aside yo
 
 * [SAP Business Application Studio](/tools/cds-editors#bas) is a cloud-based IDE with minimal local requirements and footprint. It comes pre packaged with all tools, libraries and extensions that are needed to develop CAP applications.
 * [Visual Studio Code](/tools/cds-editors#vscode) is a free and very wide-spread code editor and IDE which can be extended with Java and CDS support. It offers first class CDS language support and solid Java support for many development scenarios.
-* [IntelliJ Idea Ultimate](/tools/cds-editors#intellij) is one of the leading Java IDEs with very powerful debugging, refactoring and profiling support. Together with the CDS Plugin it offers the most powerful support for CAP Java application development.
+* [IntelliJ IDEA](/tools/cds-editors#intellij) is one of the leading Java IDEs with very powerful debugging, refactoring and profiling support. Together with the CDS Plugin it offers the most powerful support for CAP Java application development.
 
 
 #### Source Path Configuration and CDS build

--- a/tools/cds-editors.md
+++ b/tools/cds-editors.md
@@ -116,8 +116,9 @@ Restart the server when you did changes to your code using the *Debug* views res
 
 ## IntelliJ
 
-The [SAP CDS Language Support](https://github.com/cap-js/cds-intellij) plugin for IntelliJ IDEs provides syntax highlighting, code completion, formatting, and more.
-It supports free and commercial IntelliJ IDEs including IntelliJ IDEA Community, IDEA Ultimate and WebStorm.
+[SAP CDS Language Support](https://plugins.jetbrains.com/plugin/25209-sap-cds-language-support) for IntelliJ provides syntax highlighting, code completion, formatting, navigation, hover documentation, workspace symbol search, and more.
+
+The plugin supports free and commercial IntelliJ IDEs including IntelliJ IDEA Community, IDEA Ultimate and WebStorm.
 
 ![Screenshot showing an example of code completion in IntelliJ.](https://raw.githubusercontent.com/cap-js/cds-intellij/9dab0d1984e79b74074a820fe97ee6f9fb53cab7/.assets/code_completion.png){ .ignore-dark style="width:450px"}
 

--- a/tools/cds-editors.md
+++ b/tools/cds-editors.md
@@ -116,8 +116,8 @@ Restart the server when you did changes to your code using the *Debug* views res
 
 ## IntelliJ
 
-The [CAP CDS Language Support](https://github.com/cap-js/cds-intellij) plugin for IntelliJ IDEs provides syntax highlighting, code completion, formatting, and more.
-It supports commercial IntelliJ IDEs including IntelliJ IDEA Ultimate and WebStorm.
+The [SAP CDS Language Support](https://github.com/cap-js/cds-intellij) plugin for IntelliJ IDEs provides syntax highlighting, code completion, formatting, and more.
+It supports free and commercial IntelliJ IDEs including IntelliJ IDEA Community, IDEA Ultimate and WebStorm.
 
 ![Screenshot showing an example of code completion in IntelliJ.](https://raw.githubusercontent.com/cap-js/cds-intellij/9dab0d1984e79b74074a820fe97ee6f9fb53cab7/.assets/code_completion.png){ .ignore-dark style="width:450px"}
 

--- a/tools/cds-editors.md
+++ b/tools/cds-editors.md
@@ -122,7 +122,7 @@ The plugin supports free and commercial IntelliJ IDEs including IntelliJ IDEA Co
 
 ![Screenshot showing an example of code completion in IntelliJ.](https://raw.githubusercontent.com/cap-js/cds-intellij/9dab0d1984e79b74074a820fe97ee6f9fb53cab7/.assets/code_completion.png){ .ignore-dark style="width:450px"}
 
-See the [detailed feature list](https://github.com/cap-js/cds-intellij/blob/main/FEATURES.md) and the [installation instructions](https://github.com/cap-js/cds-intellij#requirements) for how to get started.
+See the [detailed feature list](https://github.com/cap-js/cds-intellij/blob/main/docs/features.md) and the [installation instructions](https://github.com/cap-js/cds-intellij#requirements) for how to get started.
 
 [Report issues and provide feedback](https://github.com/cap-js/cds-intellij/issues).
 


### PR DESCRIPTION
This is to mention our support for the Community edition of JetBrains IntelliJ IDEA since our current [plugin](https://plugins.jetbrains.com/plugin/25209-sap-cds-language-support/edit) version 2.0.0.