### PR TITLE
package managers for deployment tooling installation

### DIFF
--- a/guides/deploy/to-cf.md
+++ b/guides/deploy/to-cf.md
@@ -93,27 +93,46 @@ npm i @sap/cds        #> if necessary
 
 #### 3. Cloud MTA Build Tool {#mbt}
 
-- Run `mbt` in a terminal to check whether you've installed it.
-- If not, install it according to the [MTA Build Tool's documentation](https://sap.github.io/cloud-mta-build-tool/download).
-- For macOS/Linux machines, it's best to install using `npm`:
+Run `mbt` in a terminal to check whether you've installed it, otherwise install it as follows:
 
-  ```sh
-  npm i -g mbt
-  ```
+::: code-group
+```sh [macOS/Linux]
+npm i -g mbt
+```
+```PowerShell [Windows]
+npm i -g mbt
 
-- For Windows, [please also install `GNU Make`](https://sap.github.io/cloud-mta-build-tool/makefile/).
+# The MTA Build Tool requires GNU Make on Windows
+choco install make    # using Chocolatey
+```
+:::
+
+> On Windows, [`GNU Make` is required in addition](https://sap.github.io/cloud-mta-build-tool/makefile/). If you don't use [Chocolatey](https://chocolatey.org), follow the linked instructions to install it manually.
+
+[See the MTA Build Tool's documentation for details.](https://sap.github.io/cloud-mta-build-tool/download){.learn-more}
 
 #### 4. Cloud Foundry CLI w/ MTA Plugins {#cf-cli}
 
-- Run `cf -v` in a terminal to check whether you've installed version **8** or higher.
-- If not, install or update it according to the [Cloud Foundry CLI documentation](https://github.com/cloudfoundry/cli#downloads).
-- In addition, ensure to have the [MTA plugin for the Cloud Foundry CLI](https://github.com/cloudfoundry-incubator/multiapps-cli-plugin/tree/master/README.md) installed.
+Run `cf -v` in a terminal to check whether you've installed version **8** or higher. If not, install or update it as follows:
 
-   ```sh
-   cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-   cf install-plugin -f multiapps
-   cf install-plugin -f html5-plugin
-   ```
+::: code-group
+```sh [macOS/Linux]
+brew install cloudfoundry/tap/cf-cli@8
+```
+```PowerShell [Windows]
+choco install cloudfoundry-cli    # using Chocolatey
+```
+:::
+
+[See the Cloud Foundry CLI documentation for details](https://github.com/cloudfoundry/cli#downloads){.learn-more}
+
+In addition, ensure to have the [MTA plugin for the Cloud Foundry CLI](https://github.com/cloudfoundry-incubator/multiapps-cli-plugin/tree/master/README.md) installed:
+
+```sh
+cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+cf install-plugin -f multiapps
+cf install-plugin -f html5-plugin
+```
 
 ## Prepare for Production
 

--- a/guides/deploy/to-kyma.md
+++ b/guides/deploy/to-kyma.md
@@ -77,13 +77,30 @@ The following diagram illustrates the deployment workflow:
 + Use a Kyma-enabled [Trial Account](https://account.hanatrial.ondemand.com/) or purchase a Kyma cluster from SAP
 + You need a [Container Image Registry](#get-access-to-a-container-registry)
 + Get the required SAP BTP service entitlements
++ Make sure your SAP HANA Cloud is [mapped to your namespace](https://community.sap.com/t5/technology-blogs-by-sap/consuming-sap-hana-cloud-from-the-kyma-environment/ba-p/13552718#toc-hId-569025164)
++ Ensure SAP HANA Cloud is accessible from your Kyma cluster by [configuring trusted source IPs](https://help.sap.com/docs/HANA_CLOUD/9ae9104a46f74a6583ce5182e7fb20cb/0610e4440c7643b48d869a6376ccaecd.html)
 + Install [Docker Desktop or Docker for Linux](https://docs.docker.com/get-docker/)
 + Download and install the following command line tools:
   + [`kubectl` command line client](https://kubernetes.io/docs/tasks/tools/) for Kubernetes
   + [`pack` command line tool](https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/)
   + [`helm` command line tool](https://helm.sh/docs/intro/install/)
-+ Make sure your SAP HANA Cloud is [mapped to your namespace](https://community.sap.com/t5/technology-blogs-by-sap/consuming-sap-hana-cloud-from-the-kyma-environment/ba-p/13552718#toc-hId-569025164)
-+ Ensure SAP HANA Cloud is accessible from your Kyma cluster by [configuring trusted source IPs](https://help.sap.com/docs/HANA_CLOUD/9ae9104a46f74a6583ce5182e7fb20cb/0610e4440c7643b48d869a6376ccaecd.html)
+
+::: code-group
+```sh [macOS/Linux]
+brew install kubernetes-cli        # kubectl
+brew install buildpacks/tap/pack   # pack
+brew install helm                  # helm
+```
+```PowerShell [Windows]
+winget install --silent Kubernetes.kubectl   # kubectl
+winget install --silent Helm.Helm            # helm
+choco install buildpacks                     # pack (via Chocolatey)
+
+# Reload PATH from registry to access newly installed tools
+$env:PATH = [Environment]::GetEnvironmentVariable("PATH","Machine") `
+    + ";" + [Environment]::GetEnvironmentVariable("PATH","User")
+```
+:::
 
 #### Configure Kubernetes
 


### PR DESCRIPTION
Similar to _Get Started_, using `homebrew` (macOS/Linux) and `winget/chocolatey` (Windows) where possible to install required tooling.