### PR TITLE
chore: move and extend AsyncAPI docs

### DIFF
--- a/get-started/feature-matrix.md
+++ b/get-started/feature-matrix.md
@@ -169,7 +169,7 @@ Following is an index of the features currently covered by CAP, with status and 
 
 | Outbound Protocol Support                                        | CDS <sup>1</sup> | Node.js | Java |
 |------------------------------------------------------------------|:----------------:|:-------:|:----:|
-| [REST/OpenAPI](../tools/apis/cds-import#cdsimportfromopenapi) |       <X/>       |  <X/>   | <X/> |
+| [REST/OpenAPI](../tools/apis/cds-import#from-openapi) |       <X/>       |  <X/>   | <X/> |
 | OData V2                                                         |       <X/>       |  <X/>   | <X/> |
 | OData V4                                                         |       <X/>       |  <X/>   | <X/> |
 | GraphQL<sup>2</sup>                                              |       <C/>       |  <C/>   | <C/> |

--- a/get-started/feature-matrix.md
+++ b/get-started/feature-matrix.md
@@ -169,7 +169,7 @@ Following is an index of the features currently covered by CAP, with status and 
 
 | Outbound Protocol Support                                        | CDS <sup>1</sup> | Node.js | Java |
 |------------------------------------------------------------------|:----------------:|:-------:|:----:|
-| [REST/OpenAPI](../tools/apis/cds-import#from-openapi) |       <X/>       |  <X/>   | <X/> |
+| [REST/OpenAPI](../tools/apis/cds-import#from-openapi)            |       <X/>       |  <X/>   | <X/> |
 | OData V2                                                         |       <X/>       |  <X/>   | <X/> |
 | OData V4                                                         |       <X/>       |  <X/>   | <X/> |
 | GraphQL<sup>2</sup>                                              |       <C/>       |  <C/>   | <C/> |

--- a/guides/protocols/asyncapi.md
+++ b/guides/protocols/asyncapi.md
@@ -37,6 +37,16 @@ If you want to generate one AsyncAPI document for all the services, you can use 
 cds compile srv --service all -o docs --to asyncapi --asyncapi:merged
 ```
 
+## Importing AsyncAPI { #import}
+
+Use `cds import` to convert an AsyncAPI document into a CDS service definition:
+
+```sh
+cds import --asyncapi ~/Downloads/BookStore_AsyncAPI.json
+```
+
+[Learn more about `cds.import`](../../tools/apis/cds-import#cds-import-from-asyncapi){.learn-more}
+
 ## Programmatic Usage { #programmatic}
 
 ```js

--- a/guides/protocols/asyncapi.md
+++ b/guides/protocols/asyncapi.md
@@ -45,7 +45,7 @@ Use `cds import` to convert an AsyncAPI document into a CDS service definition:
 cds import --asyncapi ~/Downloads/BookStore_AsyncAPI.json
 ```
 
-[Learn more about `cds.import`](../../tools/apis/cds-import#cds-import-from-asyncapi){.learn-more}
+[Learn more about `cds.import`](../../tools/apis/cds-import#from-asyncapi){.learn-more}
 
 ## Programmatic Usage { #programmatic}
 

--- a/guides/protocols/asyncapi.md
+++ b/guides/protocols/asyncapi.md
@@ -10,10 +10,15 @@ description: >
   }
 </style>
 
-
 # Publishing to AsyncAPI
 
 You can convert events in CDS models to the [AsyncAPI specification](https://www.asyncapi.com), a widely adopted standard used to describe and document message-driven asynchronous APIs.
+
+Install the plugin like so:
+
+```sh
+npm add -D @cap-js/asyncapi
+```
 
 [[toc]]
 
@@ -32,7 +37,15 @@ If you want to generate one AsyncAPI document for all the services, you can use 
 cds compile srv --service all -o docs --to asyncapi --asyncapi:merged
 ```
 
-[Learn how to programmatically convert the CSN file into an AsyncAPI Document](../../node.js/cds-compile#asyncapi){.learn-more}
+## Programmatic Usage { #programmatic}
+
+```js
+const cds = require('@sap/cds')
+const { compile } = require('@cap-js/asyncapi')
+
+const csn = await cds.load(cds.env.folders.srv)
+const doc = compile(csn)
+```
 
 ## Presets { #presets}
 
@@ -84,7 +97,7 @@ Annotations will take precedence over [presets](#presets).
 | `EventCharacteristics` | Event             | x-sap-event-characteristics   |                                                                                                                         |
 | `EventStateInfo`       | Event             | x-sap-stateInfo               |                                                                                                                         |
 | `EventSchemaVersion`   | Event             | x-sap-event-version           |                                                                                                                         |
-| `EventType`            | Event             |                               | Optional; The value from this annotation will be used to<br> overwrite the default event type in the AsyncAPI document. |
+| `EventType`            | Event             |                               | Optional; The value from this annotation will be used to overwrite the default event type in the AsyncAPI document. |
 
 For example:
 
@@ -92,14 +105,13 @@ For example:
 @AsyncAPI.Title        : 'CatalogService Events'
 @AsyncAPI.SchemaVersion: '1.0.0'
 @AsyncAPI.Description  : 'Events emitted by the CatalogService.'
-
 service CatalogService {
+
   @AsyncAPI.EventSpecVersion    : '2.0'
   @AsyncAPI.EventCharacteristics: {
     ![state-transfer]: 'full-after-image'
   }
-  @AsyncAPI.EventSchemaVersion       : '1.0.0'
-
+  @AsyncAPI.EventSchemaVersion  : '1.0.0'
   event SampleEntity.Changed.v1 : projection on CatalogService.SampleEntity;
 }
 ```
@@ -113,14 +125,14 @@ For example, if both `@AsyncAPI.ShortText` and `@AsyncAPI.Extensions: { ![sap-sh
 For example:
 
 ```cds
-@AsyncAPI.Extensions   : {
-  ![foo-bar]                    : 'baz',
-  ![sap-shortText]              : 'Service Base 1'
+@AsyncAPI.Extensions: {
+  ![foo-bar]: 'baz',
+  ![sap-shortText]: 'Service Base 1'
 }
-
 service CatalogService {
-  @AsyncAPI.Extensions          : {
-    ![sap-event-source]           : '/{region}/sap.app.test'
+
+  @AsyncAPI.Extensions: {
+    ![sap-event-source]: '/{region}/sap.app.test'
   }
   event SampleEntity.Changed.v1 : projection on CatalogService.SampleEntity;
 }

--- a/guides/protocols/asyncapi.md
+++ b/guides/protocols/asyncapi.md
@@ -37,16 +37,6 @@ If you want to generate one AsyncAPI document for all the services, you can use 
 cds compile srv --service all -o docs --to asyncapi --asyncapi:merged
 ```
 
-## Importing AsyncAPI { #import}
-
-Use `cds import` to convert an AsyncAPI document into a CDS service definition:
-
-```sh
-cds import --asyncapi ~/Downloads/BookStore_AsyncAPI.json
-```
-
-[Learn more about `cds.import`](../../tools/apis/cds-import#from-asyncapi){.learn-more}
-
 ## Programmatic Usage { #programmatic}
 
 ```js
@@ -56,6 +46,16 @@ const { compile } = require('@cap-js/asyncapi')
 const csn = await cds.load(cds.env.folders.srv)
 const doc = compile(csn)
 ```
+
+## Importing AsyncAPI { #import}
+
+Use `cds import` to convert an AsyncAPI document into a CDS service definition:
+
+```sh
+cds import --asyncapi ~/Downloads/BookStore_AsyncAPI.json
+```
+
+[Learn more about `cds.import`](../../tools/apis/cds-import#from-asyncapi){.learn-more}
 
 ## Presets { #presets}
 

--- a/node.js/cds-compile.md
+++ b/node.js/cds-compile.md
@@ -232,15 +232,6 @@ Reconstructs [CDL](../cds/cdl.md) source code for the given csn model.
 
 
 
-### .asyncapi() {.method}
-
-
-Convert the CSN file into an AsyncAPI document:
-
-```js
-const doc = cds.compile.to.asyncapi(csn_file)
-```
-
 
 
 

--- a/tools/apis/cds-import.md
+++ b/tools/apis/cds-import.md
@@ -47,7 +47,7 @@ It accepts a list of namespaces whose attributes are to be retained in the CSN /
 
 <br>
 
-## cds.import.from.edmx() {.method}
+## cds.import.from.edmx() {.method #from-edmx}
 
 This API can be used to convert the OData specification file (EDMX / XML) into CSN.
 The API signature looks like this:
@@ -58,7 +58,7 @@ const csn = await cds.import.from.edmx(ODATA_EDMX_file, options)
 
 <br>
 
-## cds.import.from.openapi() {.method}
+## cds.import.from.openapi() {.method #from-openapi}
 
 This API can be used to convert the OpenAPI specification file (JSON) into CSN.
 The API signature looks like this:
@@ -69,7 +69,7 @@ const csn = await cds.import.from.openapi(OpenAPI_JSON_file)
 
 [Learn more about OpenAPI to OData Mapping.](#openapi-to-cds-odata-csn-conversion-mapping){.learn-more}
 
-## cds.import.from.asyncapi() {.method}
+## cds.import.from.asyncapi() {.method #from-asyncapi}
 
 This API can be used to convert the AsyncAPI specification file (JSON) into CSN.
 The API signature looks like this:


### PR DESCRIPTION
- documented `cds import --asyncapi` usage
- added programmatic usage (currently only documented in plugin README, which now links here, see https://github.com/cap-js/asyncapi/pull/55)
- added link to `cds.import.from.asyncapi` guide in design time CLIs (tbd if we should move this to central AsyncAPI guide)
- moved the `cds.compile.to.asyncapi` documentation to AsyncAPI guide
- fixed some (imo) suboptimal formatting in `.cds` samples