### PR TITLE
chore: add learn-more link

### DIFF
--- a/guides/integration/calesi.md
+++ b/guides/integration/calesi.md
@@ -1317,6 +1317,7 @@ This creates ultimate resilience, as the events are stored in a local outbox tab
 
 - [Inner Loop Development](inner-loops) – Understand how to develop and test integrated applications efficiently using CAP's inner loop development features.
 
+- [Outbound Authentication](../security/remote-authentication.md) - Find details about authenticating requests to remote services.
 <!--
 - [Service Bindings](service-bindings) – Learn how to configure connections to external services in a declarative way using service bindings.
 -->


### PR DESCRIPTION
I recently was looking for details about authentication / authorization for remote services and it took me some time to find it in "Authentication"; I don't think there is a cross-reference from "CAP-level Service Integration" (about integrating remote services) to the "Outbound Authentication" page (about authenticating requests to remote services) yet.