### PR TITLE
Prefer `npm start` over `npx cds-serve`

### DIFF
--- a/tools/apis/cds-build.md
+++ b/tools/apis/cds-build.md
@@ -146,11 +146,9 @@ Test the application as it runs on the cloud:
 
 ::: code-group
 ```sh [Node.js]
-cd gen/srv && npx cds-serve
-# or:
 cd gen/srv && npm start
-# or:
-npx cds-serve -p gen/srv
+# or
+npm start --prefix gen/srv
 ```
 
 ```sh [Java]


### PR DESCRIPTION
`npx` might download the wrong package from remote if it can't find the command locally.  So avoid it in clear cases like here where we have an `npm start` script.