### PR TITLE
fix: add missing blank line in build plugin doc

### DIFF
--- a/tools/apis/cds-build.md
+++ b/tools/apis/cds-build.md
@@ -140,7 +140,9 @@ cds build --for postgres
 ]
 ```
 
-> See also the command line help for further details using `cds build --help`.## Test-Run Built Projects Locally {#test-run}
+> See also the command line help for further details using `cds build --help`.
+
+## Test-Run Built Projects Locally {#test-run}
 
 Test the application as it runs on the cloud:
 


### PR DESCRIPTION
It currently looks like:
<img width="650" height="239" alt="image" src="https://github.com/user-attachments/assets/cffde95d-85c6-4222-bf03-085721ed3843" />
